### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "5"
+  - "4"
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
This might fix the Travis CI build since v4 still had npm 2 (rackt-cli needs the nested node_modules structure to work atm).
